### PR TITLE
Add the keyColumns config

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,15 @@ the environment variables as an `CLICKHOUSE_URL`.
 
 ## Destination
 
-The destination connector allows you to move data from any Conduit Source to a ClickHouse table.
+The ClickHouse Destination allows you to move data from any Conduit Source to a ClickHouse table. It takes
+a `sdk.Record` and parses it into a valid SQL query.
 
-### Table name
+### Key Handling
+
+If the `sdk.Record.Key` is empty, it is formed from `sdk.Record.Payload` data by the keys of this list (for update
+operations only).
+
+### Table Name
 
 If a record contains a `clickhouse.table` property in its metadata, it will work with this table, otherwise, it will
 fall back to use the table configured in the connector. Thus, a Destination can support multiple tables in a single
@@ -33,7 +39,8 @@ connector, as long as the user has proper access to those tables.
 
 ### Configuration Options
 
-| name        | description                                                                           | required | example                                        |
-|-------------|---------------------------------------------------------------------------------------|----------|------------------------------------------------|
-| `url`       | the [DSN](https://github.com/ClickHouse/clickhouse-go#dsn) to connect to the database | **true** | `http://username:password@host1:8123/database` |
-| `table`     | the name of a table in the database that the connector should write to, by default    | **true** | `table_name`                                   |
+| name         | description                                                                            | required | example                                        |
+|--------------|----------------------------------------------------------------------------------------|----------|------------------------------------------------|
+| `url`        | The [DSN](https://github.com/ClickHouse/clickhouse-go#dsn) to connect to the database. | **true** | `http://username:password@host1:8123/database` |
+| `table`      | The name of a table in the database that the connector should write to, by default.    | **true** | `table_name`                                   |
+| `keyColumns` | The list of key column names, separated by commas.                                     | false    | `id,name`                                      |

--- a/config/general.go
+++ b/config/general.go
@@ -21,6 +21,8 @@ const (
 	URL = "url"
 	// Table is the configuration name of the table.
 	Table = "table"
+	// KeyColumns is the configuration name of key column names, separated by commas.
+	KeyColumns = "keyColumns"
 )
 
 // A General represents a general configuration needed to connect to ClickHouse database.
@@ -29,6 +31,8 @@ type General struct {
 	URL string `json:"url" validate:"required"`
 	// Table is the configuration of the table name.
 	Table string `json:"table" validate:"required"`
+	// KeyColumns is the configuration of key column names, separated by commas.
+	KeyColumns []string `json:"keyColumns"`
 }
 
 // Parse parses general configuration.
@@ -36,6 +40,16 @@ func Parse(cfg map[string]string) (General, error) {
 	config := General{
 		URL:   strings.TrimSpace(cfg[URL]),
 		Table: strings.TrimSpace(cfg[Table]),
+	}
+
+	keyColumns := strings.Split(cfg[KeyColumns], ",")
+	config.KeyColumns = make([]string, 0, len(keyColumns))
+
+	for i := range keyColumns {
+		keyColumn := strings.TrimSpace(keyColumns[i])
+		if keyColumn != "" {
+			config.KeyColumns = append(config.KeyColumns, keyColumn)
+		}
 	}
 
 	err := validate(config)
@@ -49,7 +63,8 @@ func Parse(cfg map[string]string) (General, error) {
 // GetKeyName returns a configuration key name by struct field.
 func GetKeyName(fieldName string) string {
 	return map[string]string{
-		"URL":   URL,
-		"Table": Table,
+		"URL":        URL,
+		"Table":      Table,
+		"KeyColumns": KeyColumns,
 	}[fieldName]
 }

--- a/config/general_test.go
+++ b/config/general_test.go
@@ -33,12 +33,39 @@ func TestParseGeneral(t *testing.T) {
 		{
 			name: "valid config",
 			in: map[string]string{
-				URL:   "http://127.0.0.1:8123?username=test_user&password=test_pass_123&database=db_name",
+				URL:   "http://username:password@host1:8123/database",
 				Table: "test_table",
 			},
 			want: General{
-				URL:   "http://127.0.0.1:8123?username=test_user&password=test_pass_123&database=db_name",
-				Table: "test_table",
+				URL:        "http://username:password@host1:8123/database",
+				Table:      "test_table",
+				KeyColumns: []string{},
+			},
+		},
+		{
+			name: "valid config with keyColumns field",
+			in: map[string]string{
+				URL:        "http://username:password@host1:8123/database",
+				Table:      "test_table",
+				KeyColumns: "id",
+			},
+			want: General{
+				URL:        "http://username:password@host1:8123/database",
+				Table:      "test_table",
+				KeyColumns: []string{"id"},
+			},
+		},
+		{
+			name: "valid config with keyColumns fields",
+			in: map[string]string{
+				URL:        "http://username:password@host1:8123/database",
+				Table:      "test_table",
+				KeyColumns: "id ,name , ,  ,,",
+			},
+			want: General{
+				URL:        "http://username:password@host1:8123/database",
+				Table:      "test_table",
+				KeyColumns: []string{"id", "name"},
 			},
 		},
 		{

--- a/destination/destination.go
+++ b/destination/destination.go
@@ -61,6 +61,13 @@ func (d *Destination) Parameters() map[string]sdk.Parameter {
 			Required:    true,
 			Description: "The table name of the table in ClickHouse that the connector should write to, by default.",
 		},
+		config.KeyColumns: {
+			Default:  "",
+			Required: false,
+			Description: "The list of key column names, separated by commas. " +
+				"If the Record.Key is empty, it is formed from Record.Payload data by the keys of this list " +
+				"(for update operations only).",
+		},
 	}
 }
 
@@ -87,8 +94,9 @@ func (d *Destination) Open(ctx context.Context) (err error) {
 	}
 
 	d.writer, err = writer.NewWriter(ctx, writer.Params{
-		DB:    db,
-		Table: d.cfg.Table,
+		DB:         db,
+		Table:      d.cfg.Table,
+		KeyColumns: d.cfg.KeyColumns,
 	})
 	if err != nil {
 		return fmt.Errorf("new writer: %w", err)

--- a/destination/destination_integration_test.go
+++ b/destination/destination_integration_test.go
@@ -178,6 +178,9 @@ func TestDestination_Write_Update(t *testing.T) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	// set a KeyColumns field to the config
+	cfg[config.KeyColumns] = "int_type"
+
 	dest := NewDestination()
 
 	err = dest.Configure(ctx, cfg)
@@ -204,6 +207,23 @@ func TestDestination_Write_Update(t *testing.T) {
 	name, err := getStringFieldByIntField(db, cfg[config.Table], 42)
 	is.NoErr(err)
 	is.Equal(name, "Jane")
+
+	// update the record with no Key
+	n, err = dest.Write(ctx, []sdk.Record{
+		{
+			Operation: sdk.OperationUpdate,
+			Payload: sdk.Change{After: sdk.StructuredData{
+				"int_type":    42,
+				"string_type": "Sam",
+			}},
+		},
+	})
+	is.NoErr(err)
+	is.Equal(n, 1)
+
+	name, err = getStringFieldByIntField(db, cfg[config.Table], 42)
+	is.NoErr(err)
+	is.Equal(name, "Sam")
 
 	cancel()
 

--- a/destination/destination_test.go
+++ b/destination/destination_test.go
@@ -34,7 +34,7 @@ func TestDestination_ConfigureSuccess(t *testing.T) {
 	d := NewDestination()
 
 	err := d.Configure(context.Background(), map[string]string{
-		config.URL:   "localhost:8123?username=user&password=password&database=default",
+		config.URL:   "http://username:password@host1:8123/database",
 		config.Table: "test_table",
 	})
 	is.NoErr(err)
@@ -48,7 +48,7 @@ func TestDestination_ConfigureFail(t *testing.T) {
 	d := NewDestination()
 
 	err := d.Configure(context.Background(), map[string]string{
-		config.URL: "localhost:8123?username=user&password=password&database=default",
+		config.URL: "http://username:password@host1:8123/database",
 	})
 	is.True(err != nil)
 }


### PR DESCRIPTION
### Description

I've added the `keyColumns` config field to handle the case when there is no `sdk.Record.Key`. 

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-clickhouse/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
