### PR TITLE
Add error handling for engine tables of the log family

### DIFF
--- a/destination/destination_integration_test.go
+++ b/destination/destination_integration_test.go
@@ -531,16 +531,13 @@ func TestDestination_Write_successCheckEngines(t *testing.T) {
 					}},
 				},
 			})
-			if tt.supportMutations {
-				is.NoErr(err)
-				is.Equal(n, 1)
+			is.NoErr(err)
+			is.Equal(n, 1)
 
+			if tt.supportMutations {
 				name, err = getStringFieldByIntField(db, cfg[config.Table], 42)
 				is.NoErr(err)
 				is.Equal(name, "Sam")
-			} else {
-				is.True(strings.Contains(err.Error(), tt.mutationErrMsg))
-				is.Equal(n, 0)
 			}
 
 			// OperationDelete
@@ -550,16 +547,13 @@ func TestDestination_Write_successCheckEngines(t *testing.T) {
 					Key:       sdk.RawData(`{"Int32Type":42}`),
 				},
 			})
-			if tt.supportMutations {
-				is.NoErr(err)
-				is.Equal(n, 1)
+			is.NoErr(err)
+			is.Equal(n, 1)
 
+			if tt.supportMutations {
 				name, err = getStringFieldByIntField(db, cfg[config.Table], 42)
 				is.True(err != nil)
 				is.Equal(name, "")
-			} else {
-				is.True(strings.Contains(err.Error(), tt.mutationErrMsg))
-				is.Equal(n, 0)
 			}
 
 			cancel()

--- a/destination/writer/writer.go
+++ b/destination/writer/writer.go
@@ -38,28 +38,28 @@ const (
 
 // Writer implements a writer logic for ClickHouse destination.
 type Writer struct {
-	db                 *sqlx.DB
-	table              string
-	keyColumns         []string
-	isSupportMutations bool
-	columnTypes        map[string]string
+	db                *sqlx.DB
+	table             string
+	keyColumns        []string
+	supportsMutations bool
+	columnTypes       map[string]string
 }
 
 // Params is an incoming params for the New function.
 type Params struct {
-	DB                 *sqlx.DB
-	Table              string
-	KeyColumns         []string
-	IsSupportMutations bool
+	DB                *sqlx.DB
+	Table             string
+	KeyColumns        []string
+	SupportsMutations bool
 }
 
 // NewWriter creates new instance of the Writer.
 func NewWriter(ctx context.Context, params Params) (*Writer, error) {
 	writer := &Writer{
-		db:                 params.DB,
-		table:              params.Table,
-		keyColumns:         params.KeyColumns,
-		isSupportMutations: params.IsSupportMutations,
+		db:                params.DB,
+		table:             params.Table,
+		keyColumns:        params.KeyColumns,
+		supportsMutations: params.SupportsMutations,
 	}
 
 	columnTypes, err := getColumnTypes(ctx, writer.db, writer.table)
@@ -110,7 +110,7 @@ func (w *Writer) Insert(ctx context.Context, record sdk.Record) error {
 
 // Update updates a record.
 func (w *Writer) Update(ctx context.Context, record sdk.Record) error {
-	if !w.isSupportMutations {
+	if !w.supportsMutations {
 		sdk.Logger(ctx).Warn().Msg("The current table engine doesn't support update operation")
 
 		return nil
@@ -183,7 +183,7 @@ func (w *Writer) Update(ctx context.Context, record sdk.Record) error {
 
 // Delete deletes a record.
 func (w *Writer) Delete(ctx context.Context, record sdk.Record) error {
-	if !w.isSupportMutations {
+	if !w.supportsMutations {
 		sdk.Logger(ctx).Warn().Msg("The current table engine doesn't support delete operation")
 
 		return nil


### PR DESCRIPTION
### Description

Tables of the Log family engine do not support update and delete operations.
In case the connector tries to update or delete data to the tables with the engines of this family, the connector will return an error.

I decided to return warnings to the log instead of errors. 

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-clickhouse/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
