### PR TITLE
Corrected many minor typos

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,4 +16,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.3.1
         with:
-          version: v1.46.2
+          version: v1.50.1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,3 @@
-run:
-  go: '1.18'
-
 linters-settings:
   gofmt:
     simplify: false
@@ -25,7 +22,7 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
+    # - deadcode
     # - depguard
     - dogsled
     - durationcheck
@@ -72,7 +69,7 @@ linters:
     - predeclared
     - rowserrcheck
     - staticcheck
-    - structcheck
+    # - structcheck
     - stylecheck
     - sqlclosecheck
     # - tagliatelle
@@ -83,7 +80,7 @@ linters:
     - unconvert
     # - unparam
     - unused
-    - varcheck
+    # - varcheck
     - wastedassign
     - whitespace
   # - wrapcheck

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test:
 	go test $(GOTEST_FLAGS) -count=1 -race ./...
 
 lint:
-	golangci-lint run -c .golangci.yml --go=1.18
+	golangci-lint run -c .golangci.yml
 
 dep:
 	go mod download

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Connector uses [Golang SQL database driver](https://github.com/ClickHouse/clickh
 ## Prerequisites
 
 - [Go](https://go.dev/) 1.18
-- (optional) [golangci-lint](https://github.com/golangci/golangci-lint) 1.49.0
+- (optional) [golangci-lint](https://github.com/golangci/golangci-lint) 1.50.1
 
 ## How to build it
 

--- a/config/source_test.go
+++ b/config/source_test.go
@@ -115,7 +115,7 @@ func TestParseSource(t *testing.T) {
 			},
 		},
 		{
-			name: "success_columns_has_one_key",
+			name: "success_columns_has_two_keys",
 			in: map[string]string{
 				URL:            testURL,
 				Table:          testTable,

--- a/destination/destination.go
+++ b/destination/destination.go
@@ -88,7 +88,7 @@ func (d *Destination) Parameters() map[string]sdk.Parameter {
 		config.KeyColumns: {
 			Default:     "",
 			Required:    false,
-			Description: "Comma-separated list of column names for key handling. ",
+			Description: "Comma-separated list of column names for key handling.",
 		},
 	}
 }

--- a/spec.go
+++ b/spec.go
@@ -29,7 +29,7 @@ func Specification() sdk.Specification {
 		Name:    "clickhouse",
 		Summary: "ClickHouse destination plugin for Conduit, written in Go.",
 		Description: "ClickHouse connector is one of Conduit plugins. " +
-			"It provides a destination ClickHouse connector.",
+			"It provides both, a Source and a Destination ClickHouse connectors.",
 		Version: version,
 		Author:  "Meroxa, Inc. & Yalantis",
 	}


### PR DESCRIPTION
### Description

Corrected many minor typos:
1. update the version of `golangci-lint` to 1.50.1;
2. remove deprecated linters;
3. update the name of the `success_columns_has_two_keys` test case;
4. update `spec.go`.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-clickhouse/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
