### PR TITLE
Return records with the different mode as records with the different operation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-playground/validator/v10 v10.11.1
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.3.0
+	github.com/huandu/go-sqlbuilder v1.17.0
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/matryer/is v1.4.0
 	go.uber.org/multierr v1.8.0
@@ -26,6 +27,7 @@ require (
 	github.com/hashicorp/go-hclog v0.14.1 // indirect
 	github.com/hashicorp/go-plugin v1.4.3 // indirect
 	github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb // indirect
+	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/klauspost/compress v1.15.12 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,12 @@ github.com/hashicorp/go-plugin v1.4.3 h1:DXmvivbWD5qdiBts9TpBC7BYL1Aia5sxbRgQB+v
 github.com/hashicorp/go-plugin v1.4.3/go.mod h1:5fGEH17QVwTTcR0zV7yhDPLLmFX9YSZ38b18Udy6vYQ=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
+github.com/huandu/go-assert v1.1.5 h1:fjemmA7sSfYHJD7CUqs9qTwwfdNAx7/j2/ZlHXzNB3c=
+github.com/huandu/go-assert v1.1.5/go.mod h1:yOLvuqZwmcHIC5rIzrBhT7D3Q9c3GFnd0JrPVhn/06U=
+github.com/huandu/go-sqlbuilder v1.17.0 h1:G02PNvR6TOPiMzpOwQMKFNCiqGh19SwSbtymX7gEgpY=
+github.com/huandu/go-sqlbuilder v1.17.0/go.mod h1:nUVmMitjOmn/zacMLXT0d3Yd3RHoO2K+vy906JzqxMI=
+github.com/huandu/xstrings v1.3.2 h1:L18LIDzqlW6xN2rEkpdV8+oL/IXWJ1APd+vsdYy4Wdw=
+github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 github.com/jhump/protoreflect v1.10.2-0.20211108190630-d551e22cd340 h1:Vdzuzjwa0C0Vd7+eBTXaEKqarx2S0TG1u5TTugjHLkk=
 github.com/jmoiron/sqlx v1.3.5 h1:vFFPA71p1o5gAeqtEAwLU4dnX2napprKtHr7PYIcN3g=
@@ -152,6 +158,7 @@ github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFR
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/source/iterator/iterator.go
+++ b/source/iterator/iterator.go
@@ -18,39 +18,25 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/conduitio-labs/conduit-connector-clickhouse/config"
 	sdk "github.com/conduitio/conduit-connector-sdk"
+	"github.com/huandu/go-sqlbuilder"
 	"github.com/jmoiron/sqlx"
+	"go.uber.org/multierr"
 )
 
-// metadata related.
-const (
-	metadataTable = "clickhouse.table"
-
-	querySelectRowsFmt = "SELECT %s FROM %s%s ORDER BY %s ASC LIMIT %d;"
-	whereClauseFmt     = " WHERE %s > ?"
-
-	querySelectPKs = `
-SELECT 
-  name 
-FROM 
-  system.columns 
-WHERE 
-  is_in_primary_key = 1 
-  AND table = ? 
-  AND database = ?;
-`
-)
+// metadataFieldTable is a name of a record metadata field that stores a ClickHouse table name.
+const metadataFieldTable = "clickhouse.table"
 
 // Iterator is an implementation of an iterator for ClickHouse.
 type Iterator struct {
-	db   *sqlx.DB
-	rows *sqlx.Rows
+	db       *sqlx.DB
+	rows     *sqlx.Rows
+	position *Position
 
-	// last processed orderingColumn value
-	lastProcessedVal any
 	// table name
 	table string
 	// name of the column that iterator will use for setting key in record
@@ -62,36 +48,46 @@ type Iterator struct {
 	columns []string
 	// size of batch
 	batchSize int
-	// database name
-	database string
-}
-
-// Params is an incoming iterator params for the New function.
-type Params struct {
-	DB               *sqlx.DB
-	LastProcessedVal any
-	Table            string
-	KeyColumns       []string
-	OrderingColumn   string
-	Columns          []string
-	BatchSize        int
-	Database         string
 }
 
 // New creates a new instance of the iterator.
-func New(ctx context.Context, params Params) (*Iterator, error) {
+func New(ctx context.Context, driverName string, pos *Position, config config.Source) (*Iterator, error) {
+	var err error
+
 	iterator := &Iterator{
-		db:               params.DB,
-		lastProcessedVal: params.LastProcessedVal,
-		table:            params.Table,
-		keyColumns:       params.KeyColumns,
-		orderingColumn:   params.OrderingColumn,
-		columns:          params.Columns,
-		batchSize:        params.BatchSize,
-		database:         params.Database,
+		position:       pos,
+		table:          config.Table,
+		keyColumns:     config.KeyColumns,
+		orderingColumn: config.OrderingColumn,
+		batchSize:      config.BatchSize,
 	}
 
-	err := iterator.populateKeyColumns(ctx)
+	iterator.db, err = sqlx.Open(driverName, config.URL)
+	if err != nil {
+		return nil, fmt.Errorf("open db connection: %w", err)
+	}
+
+	if iterator.position.LastProcessedValue == nil {
+		latestSnapshotValue, latestValErr := iterator.latestSnapshotValue(ctx)
+		if latestValErr != nil {
+			return nil, fmt.Errorf("get latest snapshot value: %w", latestValErr)
+		}
+
+		if config.Snapshot {
+			// set the LatestSnapshotValue to specify which record the snapshot iterator will work to
+			iterator.position.LatestSnapshotValue = latestSnapshotValue
+		} else {
+			// set the LastProcessedValue to skip a snapshot of the entire table
+			iterator.position.LastProcessedValue = latestSnapshotValue
+		}
+	}
+
+	options, err := clickhouse.ParseDSN(config.URL)
+	if err != nil {
+		return nil, fmt.Errorf("parse dsn: %w", err)
+	}
+
+	err = iterator.populateKeyColumns(ctx, options.Auth.Database)
 	if err != nil {
 		return nil, fmt.Errorf("populate key columns: %w", err)
 	}
@@ -106,7 +102,32 @@ func New(ctx context.Context, params Params) (*Iterator, error) {
 
 // HasNext returns a bool indicating whether the iterator has the next record to return or not.
 func (iter *Iterator) HasNext(ctx context.Context) (bool, error) {
-	return iter.hasNext(ctx)
+	if iter.rows != nil && iter.rows.Next() {
+		return true, nil
+	}
+
+	if err := iter.loadRows(ctx); err != nil {
+		return false, fmt.Errorf("load rows: %w", err)
+	}
+
+	if iter.rows.Next() {
+		return true, nil
+	}
+
+	if iter.position.LatestSnapshotValue != nil {
+		// switch to CDC mode
+		iter.position.LastProcessedValue = iter.position.LatestSnapshotValue
+		iter.position.LatestSnapshotValue = nil
+
+		// and load new rows
+		if err := iter.loadRows(ctx); err != nil {
+			return false, fmt.Errorf("load rows: %w", err)
+		}
+
+		return iter.rows.Next(), nil
+	}
+
+	return false, nil
 }
 
 // Next returns the next record.
@@ -137,68 +158,70 @@ func (iter *Iterator) Next(ctx context.Context) (sdk.Record, error) {
 
 	// set a new position into the variable,
 	// to avoid saving position into the struct until we marshal the position
-	positionBytes, err := json.Marshal(row[iter.orderingColumn])
+	position := *iter.position
+	// set the value from iter.orderingColumn column you chose
+	position.LastProcessedValue = row[iter.orderingColumn]
+
+	convertedPosition, err := position.marshal()
 	if err != nil {
-		return sdk.Record{}, fmt.Errorf("marshal position: %w", err)
+		return sdk.Record{}, fmt.Errorf("convert position :%w", err)
 	}
 
-	iter.lastProcessedVal = row[iter.orderingColumn]
+	iter.position = &position
 
 	metadata := sdk.Metadata{
-		metadataTable: iter.table,
+		metadataFieldTable: iter.table,
 	}
 	metadata.SetCreatedAt(time.Now())
 
-	return sdk.Util.Source.NewRecordCreate(
-		positionBytes,
-		metadata,
-		key,
-		sdk.RawData(rowBytes),
-	), nil
+	if position.LatestSnapshotValue != nil {
+		return sdk.Util.Source.NewRecordSnapshot(convertedPosition, metadata, key, sdk.RawData(rowBytes)), nil
+	}
+
+	return sdk.Util.Source.NewRecordCreate(convertedPosition, metadata, key, sdk.RawData(rowBytes)), nil
 }
 
 // Stop stops iterators and closes database connection.
-func (iter *Iterator) Stop() (err error) {
+func (iter *Iterator) Stop() error {
+	var err error
+
 	if iter.rows != nil {
-		return iter.rows.Close()
+		err = iter.rows.Close()
+	}
+
+	if iter.db != nil {
+		err = multierr.Append(err, iter.db.Close())
+	}
+
+	if err != nil {
+		return fmt.Errorf("close db rows and db: %w", err)
 	}
 
 	return nil
 }
 
-// returns a bool indicating whether the source has the next record to return or not.
-func (iter *Iterator) hasNext(ctx context.Context) (bool, error) {
-	if iter.rows != nil && iter.rows.Next() {
-		return true, nil
-	}
-
-	if err := iter.loadRows(ctx); err != nil {
-		return false, fmt.Errorf("load rows: %w", err)
-	}
-
-	return iter.rows.Next(), nil
-}
-
-// selects a batch of rows from a database, based on the
+// loadRows selects a batch of rows from a database, based on the
 // table, columns, orderingColumn, batchSize and the current position.
 func (iter *Iterator) loadRows(ctx context.Context) error {
-	var (
-		args        []any
-		whereClause string
-
-		columns = "*"
-	)
+	sb := sqlbuilder.NewSelectBuilder().
+		Select("*").
+		From(iter.table).
+		OrderBy(iter.orderingColumn).
+		Limit(iter.batchSize)
 
 	if len(iter.columns) > 0 {
-		columns = strings.Join(iter.columns, ",")
+		sb.Select(iter.columns...)
 	}
 
-	if iter.lastProcessedVal != nil {
-		whereClause = fmt.Sprintf(whereClauseFmt, iter.orderingColumn)
-		args = append(args, iter.lastProcessedVal)
+	if iter.position.LastProcessedValue != nil {
+		sb.Where(sb.GreaterThan(iter.orderingColumn, iter.position.LastProcessedValue))
 	}
 
-	query := fmt.Sprintf(querySelectRowsFmt, columns, iter.table, whereClause, iter.orderingColumn, iter.batchSize)
+	if iter.position.LatestSnapshotValue != nil {
+		sb.Where(sb.LessEqualThan(iter.orderingColumn, iter.position.LatestSnapshotValue))
+	}
+
+	query, args := sb.Build()
 
 	rows, err := iter.db.QueryxContext(ctx, query, args...)
 	if err != nil {
@@ -210,17 +233,29 @@ func (iter *Iterator) loadRows(ctx context.Context) error {
 	return nil
 }
 
-// populateKeyColumns populates keyColumns field if it's empty.
-// It populates with the primary keys of the table, if they exist,
-// or with the orderingColumn.
-func (iter *Iterator) populateKeyColumns(ctx context.Context) error {
+// populateKeyColumns populates keyColumn from the database metadata
+// or from the orderingColumn configuration field in the described order if it's empty.
+func (iter *Iterator) populateKeyColumns(ctx context.Context, database string) error {
 	if len(iter.keyColumns) != 0 {
 		return nil
 	}
 
-	rows, err := iter.db.QueryxContext(ctx, querySelectPKs, iter.table, iter.database)
+	sb := sqlbuilder.NewSelectBuilder().
+		Select("name").
+		From("system.columns").
+		Where("is_in_primary_key = 1")
+
+	sb.Where(sb.Equal("table", iter.table))
+
+	if database != "" {
+		sb.Where(sb.Equal("database", database))
+	}
+
+	query, args := sb.Build()
+
+	rows, err := iter.db.QueryxContext(ctx, query, args...)
 	if err != nil {
-		return fmt.Errorf("execute select primary keys query: %w", err)
+		return fmt.Errorf("execute select primary keys query %q, %v: %w", query, args, err)
 	}
 	defer rows.Close()
 
@@ -240,4 +275,29 @@ func (iter *Iterator) populateKeyColumns(ctx context.Context) error {
 	iter.keyColumns = []string{iter.orderingColumn}
 
 	return nil
+}
+
+// latestSnapshotValue returns most recent value of orderingColumn column.
+func (iter *Iterator) latestSnapshotValue(ctx context.Context) (any, error) {
+	var latestSnapshotValue any
+
+	query := sqlbuilder.NewSelectBuilder().
+		Select(iter.orderingColumn).
+		From(iter.table).
+		OrderBy(iter.orderingColumn).Desc().
+		Limit(1).
+		String()
+
+	rows, err := iter.db.QueryxContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("execute select latest snapshot value query %q: %w", query, err)
+	}
+
+	for rows.Next() {
+		if err = rows.Scan(&latestSnapshotValue); err != nil {
+			return nil, fmt.Errorf("scan latest snapshot value: %w", err)
+		}
+	}
+
+	return latestSnapshotValue, nil
 }

--- a/source/iterator/position.go
+++ b/source/iterator/position.go
@@ -1,0 +1,55 @@
+// Copyright © 2022 Meroxa, Inc. & Yalantis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iterator
+
+import (
+	"encoding/json"
+	"fmt"
+
+	sdk "github.com/conduitio/conduit-connector-sdk"
+)
+
+// Position represents ClickHouse's position.
+type Position struct {
+	// LastProcessedValue represents the last processed value from ordering column.
+	LastProcessedValue any `json:"lastProcessedValue"`
+	// LatestSnapshotValue represents the most recent value of ordering column.
+	LatestSnapshotValue any `json:"latestSnapshotValue"`
+}
+
+// ParseSDKPosition parses sdk.Position and returns Position.
+func ParseSDKPosition(position sdk.Position) (*Position, error) {
+	var pos Position
+
+	if position == nil {
+		return &pos, nil
+	}
+
+	if err := json.Unmarshal(position, &pos); err != nil {
+		return nil, fmt.Errorf("unmarshal sdk.Position into Position: %w", err)
+	}
+
+	return &pos, nil
+}
+
+// marshal marshals Position and returns sdk.Position or an error.
+func (p Position) marshal() (sdk.Position, error) {
+	positionBytes, err := json.Marshal(p)
+	if err != nil {
+		return nil, fmt.Errorf("marshal position: %w", err)
+	}
+
+	return positionBytes, nil
+}

--- a/source/iterator/position_test.go
+++ b/source/iterator/position_test.go
@@ -1,0 +1,180 @@
+// Copyright © 2022 Meroxa, Inc. & Yalantis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iterator
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	sdk "github.com/conduitio/conduit-connector-sdk"
+)
+
+func TestParseSDKPosition(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   sdk.Position
+		want Position
+		err  error
+	}{
+		{
+			name: "success_position_is_nil",
+			in:   nil,
+			want: Position{},
+		},
+		{
+			name: "success_float64_fields",
+			in: sdk.Position(`{
+			   "lastProcessedValue":10,
+			   "latestSnapshotValue":30
+			}`),
+			want: Position{
+				LastProcessedValue:  float64(10),
+				LatestSnapshotValue: float64(30),
+			},
+		},
+		{
+			name: "success_string_fields",
+			in: sdk.Position(`{
+			   "lastProcessedValue":"abc",
+			   "latestSnapshotValue":"def"
+			}`),
+			want: Position{
+				LastProcessedValue:  "abc",
+				LatestSnapshotValue: "def",
+			},
+		},
+		{
+			name: "success_lastProcessedValue_only",
+			in: sdk.Position(`{
+			   "lastProcessedValue":10
+			}`),
+			want: Position{
+				LastProcessedValue: float64(10),
+			},
+		},
+		{
+			name: "success_latestSnapshotValue_only",
+			in: sdk.Position(`{
+			   "latestSnapshotValue":30
+			}`),
+			want: Position{
+				LatestSnapshotValue: float64(30),
+			},
+		},
+		{
+			name: "failure_required_url_and_table",
+			in:   sdk.Position("invalid"),
+			err: errors.New("unmarshal sdk.Position into Position: " +
+				"invalid character 'i' looking for beginning of value"),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ParseSDKPosition(tt.in)
+			if err != nil {
+				if tt.err == nil {
+					t.Errorf("unexpected error: %s", err.Error())
+
+					return
+				}
+
+				if err.Error() != tt.err.Error() {
+					t.Errorf("unexpected error, got: %s, want: %s", err.Error(), tt.err.Error())
+
+					return
+				}
+
+				return
+			}
+
+			if !reflect.DeepEqual(*got, tt.want) {
+				t.Errorf("got: %v, want: %v", *got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMarshal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   Position
+		want sdk.Position
+	}{
+		{
+			name: "success_position_is_nil",
+			in:   Position{},
+			want: sdk.Position(`{"lastProcessedValue":null,"latestSnapshotValue":null}`),
+		},
+		{
+			name: "success_integer_fields",
+			in: Position{
+				LastProcessedValue:  10,
+				LatestSnapshotValue: 30,
+			},
+			want: sdk.Position(`{"lastProcessedValue":10,"latestSnapshotValue":30}`),
+		},
+		{
+			name: "success_string_fields",
+			in: Position{
+				LastProcessedValue:  "abc",
+				LatestSnapshotValue: "def",
+			},
+			want: sdk.Position(`{"lastProcessedValue":"abc","latestSnapshotValue":"def"}`),
+		},
+		{
+			name: "success_lastProcessedValue_only",
+			in: Position{
+				LastProcessedValue: float64(10),
+			},
+			want: sdk.Position(`{"lastProcessedValue":10,"latestSnapshotValue":null}`),
+		},
+		{
+			name: "success_latestSnapshotValue_only",
+			in: Position{
+				LatestSnapshotValue: float64(30),
+			},
+			want: sdk.Position(`{"lastProcessedValue":null,"latestSnapshotValue":30}`),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := tt.in.marshal()
+			if err != nil {
+				t.Errorf("unexpected error: %s", err.Error())
+
+				return
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got: %v, want: %v", string(got), string(tt.want))
+			}
+		})
+	}
+}

--- a/source/source_test.go
+++ b/source/source_test.go
@@ -164,5 +164,5 @@ func TestSource_Teardown_fail(t *testing.T) {
 	}
 
 	err := s.Teardown(context.Background())
-	is.Equal(err.Error(), "some error")
+	is.Equal(err.Error(), "stop iterator: some error")
 }


### PR DESCRIPTION
### Description

I've split the iterator to return records with `snapshot` and `create` operations.
Also, I've added a sql-builder to build SQL requests. 

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-clickhouse/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
