### PR TITLE
Remove  configuration parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ configuration.
 | `table`          | Name of the table that the connector should read.                                                                                                                   | **true** | `table_name`                                   |
 | `orderingColumn` | Column name that the connector will use for ordering rows. Column must contain unique values and suitable for sorting, otherwise the snapshot won't work correctly. | **true** | `id`                                           |
 | `keyColumns`     | Comma-separated list of column names to build the `sdk.Record.Key`. See more: [key handling](#key-handling).                                                        | false    | `id,name`                                      |
-| `columns`        | Comma-separated list of column names that should be included in each payload of the `sdk.Record`. By default includes all columns.                                  | false    | `id,name,age`                                  |
 | `batchSize`      | Size of rows batch. Min is 1 and max is 100000. The default is 1000.                                                                                                | false    | `100`                                          |
 
 #### Key handling

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -74,7 +74,6 @@ func getKeyName(fieldName string) string {
 		"Table":          Table,
 		"KeyColumns":     KeyColumns,
 		"OrderingColumn": OrderingColumn,
-		"Columns":        Columns,
 		"BatchSize":      BatchSize,
 	}[fieldName]
 }

--- a/config/source_test.go
+++ b/config/source_test.go
@@ -124,7 +124,6 @@ func TestParseSource(t *testing.T) {
 				URL:            testURL,
 				Table:          testTable,
 				OrderingColumn: "id",
-				Columns:        "id",
 			},
 			want: Source{
 				Configuration: Configuration{
@@ -134,7 +133,6 @@ func TestParseSource(t *testing.T) {
 				OrderingColumn: "id",
 				Snapshot:       defaultSnapshot,
 				BatchSize:      defaultBatchSize,
-				Columns:        []string{"id"},
 			},
 		},
 		{
@@ -143,7 +141,6 @@ func TestParseSource(t *testing.T) {
 				URL:            testURL,
 				Table:          testTable,
 				OrderingColumn: "id",
-				Columns:        "id,name",
 			},
 			want: Source{
 				Configuration: Configuration{
@@ -153,7 +150,6 @@ func TestParseSource(t *testing.T) {
 				OrderingColumn: "id",
 				Snapshot:       defaultSnapshot,
 				BatchSize:      defaultBatchSize,
-				Columns:        []string{"id", "name"},
 			},
 		},
 		{
@@ -162,7 +158,6 @@ func TestParseSource(t *testing.T) {
 				URL:            testURL,
 				Table:          testTable,
 				OrderingColumn: "id",
-				Columns:        "id, name",
 			},
 			want: Source{
 				Configuration: Configuration{
@@ -172,7 +167,6 @@ func TestParseSource(t *testing.T) {
 				OrderingColumn: "id",
 				Snapshot:       defaultSnapshot,
 				BatchSize:      defaultBatchSize,
-				Columns:        []string{"id", "name"},
 			},
 		},
 		{
@@ -181,7 +175,6 @@ func TestParseSource(t *testing.T) {
 				URL:            testURL,
 				Table:          testTable,
 				OrderingColumn: "id",
-				Columns:        "id,name ",
 			},
 			want: Source{
 				Configuration: Configuration{
@@ -191,7 +184,6 @@ func TestParseSource(t *testing.T) {
 				OrderingColumn: "id",
 				Snapshot:       defaultSnapshot,
 				BatchSize:      defaultBatchSize,
-				Columns:        []string{"id", "name"},
 			},
 		},
 		{
@@ -200,7 +192,6 @@ func TestParseSource(t *testing.T) {
 				URL:            testURL,
 				Table:          testTable,
 				OrderingColumn: "id",
-				Columns:        " id,name",
 			},
 			want: Source{
 				Configuration: Configuration{
@@ -210,7 +201,6 @@ func TestParseSource(t *testing.T) {
 				OrderingColumn: "id",
 				Snapshot:       defaultSnapshot,
 				BatchSize:      defaultBatchSize,
-				Columns:        []string{"id", "name"},
 			},
 		},
 		{
@@ -219,7 +209,6 @@ func TestParseSource(t *testing.T) {
 				URL:            testURL,
 				Table:          testTable,
 				OrderingColumn: "id",
-				Columns:        "id ,name",
 			},
 			want: Source{
 				Configuration: Configuration{
@@ -229,7 +218,6 @@ func TestParseSource(t *testing.T) {
 				OrderingColumn: "id",
 				Snapshot:       defaultSnapshot,
 				BatchSize:      defaultBatchSize,
-				Columns:        []string{"id", "name"},
 			},
 		},
 		{
@@ -238,7 +226,6 @@ func TestParseSource(t *testing.T) {
 				URL:            testURL,
 				Table:          testTable,
 				OrderingColumn: "id",
-				Columns:        "id,  name",
 			},
 			want: Source{
 				Configuration: Configuration{
@@ -248,15 +235,13 @@ func TestParseSource(t *testing.T) {
 				OrderingColumn: "id",
 				Snapshot:       defaultSnapshot,
 				BatchSize:      defaultBatchSize,
-				Columns:        []string{"id", "name"},
 			},
 		},
 		{
 			name: "failure_required_orderingColumn",
 			in: map[string]string{
-				URL:     testURL,
-				Table:   testTable,
-				Columns: "id,name,age",
+				URL:   testURL,
+				Table: testTable,
 			},
 			err: fmt.Errorf("%q must be set", OrderingColumn),
 		},
@@ -279,27 +264,6 @@ func TestParseSource(t *testing.T) {
 				BatchSize:      "a",
 			},
 			err: fmt.Errorf(`invalid %q: strconv.Atoi: parsing "a": invalid syntax`, BatchSize),
-		},
-		{
-			name: "failure_missed_orderingColumn_in_columns",
-			in: map[string]string{
-				URL:            testURL,
-				Table:          testTable,
-				OrderingColumn: "id",
-				Columns:        "name,age",
-			},
-			err: fmt.Errorf("columns must include %q", OrderingColumn),
-		},
-		{
-			name: "failure_missed_keyColumn_in_columns",
-			in: map[string]string{
-				URL:            testURL,
-				Table:          testTable,
-				OrderingColumn: "id",
-				KeyColumns:     "name",
-				Columns:        "id,age",
-			},
-			err: fmt.Errorf("columns must include all %q", KeyColumns),
 		},
 		{
 			name: "failure_batchSize_is_too_big",
@@ -330,26 +294,6 @@ func TestParseSource(t *testing.T) {
 				BatchSize:      "-1",
 			},
 			err: fmt.Errorf("%w", fmt.Errorf("%q is out of range", BatchSize)),
-		},
-		{
-			name: "failure_columns_ends_with_comma",
-			in: map[string]string{
-				URL:            testURL,
-				Table:          testTable,
-				OrderingColumn: "id",
-				Columns:        "id,name,",
-			},
-			err: fmt.Errorf("invalid %q", Columns),
-		},
-		{
-			name: "failure_columns_starts_with_comma",
-			in: map[string]string{
-				URL:            testURL,
-				Table:          testTable,
-				OrderingColumn: "id",
-				Columns:        ",id,name",
-			},
-			err: fmt.Errorf("invalid %q", Columns),
 		},
 	}
 

--- a/source/iterator/iterator.go
+++ b/source/iterator/iterator.go
@@ -43,9 +43,6 @@ type Iterator struct {
 	keyColumns []string
 	// name of the column that iterator will use for sorting data
 	orderingColumn string
-	// list of table's columns for record payload.
-	// if empty - will get all columns
-	columns []string
 	// size of batch
 	batchSize int
 }
@@ -208,10 +205,6 @@ func (iter *Iterator) loadRows(ctx context.Context) error {
 		From(iter.table).
 		OrderBy(iter.orderingColumn).
 		Limit(iter.batchSize)
-
-	if len(iter.columns) > 0 {
-		sb.Select(iter.columns...)
-	}
 
 	if iter.position.LastProcessedValue != nil {
 		sb.Where(sb.GreaterThan(iter.orderingColumn, iter.position.LastProcessedValue))

--- a/source/source.go
+++ b/source/source.go
@@ -75,12 +75,6 @@ func (s *Source) Parameters() map[string]sdk.Parameter {
 			Required:    false,
 			Description: "Whether the connector will take a snapshot of the entire table before starting cdc mode.",
 		},
-		config.Columns: {
-			Default:  "",
-			Required: false,
-			Description: "Comma-separated list of column names that should be included in each payload of the " +
-				"sdk.Record. By default includes all columns.",
-		},
 		config.BatchSize: {
 			Default:     "1000",
 			Required:    false,


### PR DESCRIPTION
### Description

I've removed a `colomns` source configuration parameter.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-clickhouse/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
